### PR TITLE
Remove redundant copy

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -48,7 +48,6 @@ RUN sed -i 's:/opt/axis/sdk:/opt/axis/acapsdk:g' /opt/axis/acapsdk/environment-s
 ARG ARCH=aarch64
 COPY --from=api /opt/axis/sdk/temp/sysroots/${ARCH}/usr/lib/ /opt/axis/acapsdk/sysroots/${ARCH}/usr/lib/
 COPY --from=api /opt/axis/sdk/temp/sysroots/${ARCH}/usr/include/ /opt/axis/acapsdk/sysroots/${ARCH}/usr/include/
-COPY --from=api /opt/axis/sdk/temp/sysroots/${ARCH}/usr/lib/pkgconfig/ /opt/axis/acapsdk/sysroots/${ARCH}/usr/lib/pkgconfig/
 COPY --from=api /opt/axis/sdk/temp/sysroots/${ARCH}/usr/share/protobuf/ /opt/axis/acapsdk/sysroots/${ARCH}/usr/share/protobuf/
 
 # Make the environment sourced for interactive Bash users

--- a/Dockerfile.armv7hf
+++ b/Dockerfile.armv7hf
@@ -48,7 +48,6 @@ RUN sed -i 's:/opt/axis/sdk:/opt/axis/acapsdk:g' /opt/axis/acapsdk/environment-s
 ARG ARCH=armv7hf
 COPY --from=api /opt/axis/sdk/temp/sysroots/${ARCH}/usr/lib/ /opt/axis/acapsdk/sysroots/${ARCH}/usr/lib/
 COPY --from=api /opt/axis/sdk/temp/sysroots/${ARCH}/usr/include/ /opt/axis/acapsdk/sysroots/${ARCH}/usr/include/
-COPY --from=api /opt/axis/sdk/temp/sysroots/${ARCH}/usr/lib/pkgconfig/ /opt/axis/acapsdk/sysroots/${ARCH}/usr/lib/pkgconfig/
 COPY --from=api /opt/axis/sdk/temp/sysroots/${ARCH}/usr/share/protobuf/ /opt/axis/acapsdk/sysroots/${ARCH}/usr/share/protobuf/
 
 # Add a missing file for OpenGL


### PR DESCRIPTION
In recent months the nightly tests have sometimes failed due to what
looks like a step that is not doing anything, giving error message,
  failed to export image: failed to create image: failed to get layer
  sha256:<SHA256>: layer does not exist

Since the Docker COPY command should be recursive, the removed lines
in the Dockerfiles should be redundant.