### PR TITLE
Add --disable-new-dtags to linker parameters

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -41,8 +41,10 @@ RUN curl --fail -L https://repo1.maven.org/maven2/com/google/protobuf/protoc/${A
 RUN sed -i 's#export PATH=#export PATH=/opt/axis/acapsdk/axis-acap-manifest-tools/manifest-generator:#g' /opt/axis/acapsdk/environment-setup*
 
 # Update paths and add explicit sdk path to linker in environment-setup script
+# Add the --disable-new-dtags parameter to the default LDFLAGS to solve dynamic library rpath issues
 RUN sed -i 's:/opt/axis/sdk:/opt/axis/acapsdk:g' /opt/axis/acapsdk/environment-setup* && \
-  sed -i '/\(CC\|CPP\|CXX\)=/s:"$: -L$SDKTARGETSYSROOT/usr/lib":g' /opt/axis/acapsdk/environment-setup*
+  sed -i '/\(CC\|CPP\|CXX\)=/s:"$: -L$SDKTARGETSYSROOT/usr/lib":g' /opt/axis/acapsdk/environment-setup* && \
+  sed -i '/^export LDFLAGS=/ s:"$: -Wl,--disable-new-dtags":' /opt/axis/acapsdk/environment-setup*
 
 # Copy the lib, include, .pc and Axis protobuf files from the API container
 ARG ARCH=aarch64

--- a/Dockerfile.armv7hf
+++ b/Dockerfile.armv7hf
@@ -41,8 +41,10 @@ RUN curl --fail -L https://repo1.maven.org/maven2/com/google/protobuf/protoc/${A
 RUN sed -i 's#export PATH=#export PATH=/opt/axis/acapsdk/axis-acap-manifest-tools/manifest-generator:#g' /opt/axis/acapsdk/environment-setup*
 
 # Update paths and add explicit sdk path to linker in environment-setup script
+# Add the --disable-new-dtags parameter to the default LDFLAGS to solve dynamic library rpath issues
 RUN sed -i 's:/opt/axis/sdk:/opt/axis/acapsdk:g' /opt/axis/acapsdk/environment-setup* && \
-  sed -i '/\(CC\|CPP\|CXX\)=/s:"$: -L$SDKTARGETSYSROOT/usr/lib":g' /opt/axis/acapsdk/environment-setup*
+  sed -i '/\(CC\|CPP\|CXX\)=/s:"$: -L$SDKTARGETSYSROOT/usr/lib":g' /opt/axis/acapsdk/environment-setup* && \
+  sed -i '/^export LDFLAGS=/ s:"$: -Wl,--disable-new-dtags":' /opt/axis/acapsdk/environment-setup*
 
 # Copy the lib, include, .pc and Axis protobuf files from the API container
 ARG ARCH=armv7hf


### PR DESCRIPTION
This is to fix an issue where the transitive behaviour of rpath was
changed in a binutils update. See
https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1737608 for more
information.